### PR TITLE
Allow mapping of synced folder at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ On your local computer
 - Install vagrant
 - Clone this repo locally
 - `vagrant up` in the cloned directory of this repo
+  - NOTE: if you don't like the default of `src`, you can use `SYNCED_FOLDER` ENV
+  - EXAMPLE: `SYNCED_FOLDER="~/projects" vagrant up`
 - git clone the repo you want to work on into `src`
-  - NOTE: you can do this for multiple projects instead of having a VM for each.
+  - NOTE: if you changed with `ENV['SYNCED_FOLDER']` wherever you change it to
+  - NOTE: you can sync a directory containing multiple projects instead of having a VM for each.
 - `vagrant ssh` gets you a shell on the rails vm
 - Note: do all your development using your preferred tools on your local
 computer. Do your `git` work on your local as well.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "install-ruby.sh", args: "2.3.1 bundle", privileged: false
   config.vm.provision :shell, path: "install-heroku-cli.sh"
 
-  config.vm.synced_folder "src", "/vagrant/src"
+  config.vm.synced_folder ENV['SYNCED_FOLDER'] || "src", "/vagrant/src"
   config.vm.network "forwarded_port", guest: 5000, host: 5000
 end


### PR DESCRIPTION
What:

* it is now possible to provide a folder to sync with the vm
  at runtime rather than having to update the config manually
  if the default previously chosen was not ideal for your work
preferences
* if no synced folder is provided, it falls back on the previous
  value of `src`

Why:

* this vagrant vm should not dictate the location of source files
  for a developer. If y'all have strong opinions on how to manage your
  project files, you shouldn't be forced to change those

How:

* If you set `ENV['SYNCED_FOLDER']`, the vagrant config will now map
  that to `/vagrant/src`
* If you do not set that, the previous default remains
* You can now do something like: `SYNCED_FOLDER="~/projects" vagrant up`
  or set `SYNCED_FOLDER` in your `.bash_profile`