### PR TITLE
Adds Python setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-MIT Libraries Development Rails Box
+MIT Libraries Development Rails and Python Box
 ===
 This repository contains a VagrantFile and support scripts that will configure
-a local VM suitable for developing Rails applications.
+a local VM suitable for developing Rails or Python applications.
 
 What it installs
 ==
@@ -21,18 +21,26 @@ On your local computer
 - git clone the repo you want to work on into `src`
   - NOTE: if you changed with `ENV['SYNCED_FOLDER']` wherever you change it to
   - NOTE: you can sync a directory containing multiple projects instead of having a VM for each.
-- `vagrant ssh` gets you a shell on the rails vm
+- `vagrant ssh` gets you a shell on the vm
 - Note: do all your development using your preferred tools on your local
 computer. Do your `git` work on your local as well.
 - `vagrant halt` when you want to shutdown the vm (`vagrant up` to bring it
    back)
 
-On the rails VM
+On the VM with rails
 - `cd /vagrant/src/YOUR_PROJECT` gets you to the linked directory
 - `bundle install` whenever you need to install gems
 - `bin/rails test` to run tests
 - `heroku local` to run a dev server. We use `heroku local` instead of
 `bin/rails server` so we can easily load environment variables by dropping a
+`.env` file in `src` on your local (or `/vagrant/src/YOUR_PROJECT` in the vm
+as they are the same thing)
+
+On the VM with python
+- `cd /vagrant/src/YOUR_PROJECT` gets you to the linked directory
+- `pip install` whenever you need to install packages
+- `py.test` to run tests
+- `heroku local` to run a dev server. We use `heroku local` so we can easily load environment variables by dropping a
 `.env` file in `src` on your local (or `/vagrant/src/YOUR_PROJECT` in the vm
 as they are the same thing)
 
@@ -42,6 +50,6 @@ This does not use Ansible due to a requirement to work on Windows.
 
 Making Changes
 ==
-If you end up needing additional packages installed to get gems to work,
+If you end up needing additional packages installed to get gems or python packages to work,
 adding them to the `provision.sh` will probably make it easier later if it's a
-fairly common gem.
+fairly common library.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "provision.sh"
   config.vm.provision :shell, path: "install-rvm.sh", args: "stable", privileged: false
   config.vm.provision :shell, path: "install-ruby.sh", args: "2.4.1 bundle", privileged: false
+  config.vm.provision :shell, path: "install-python.sh"
   config.vm.provision :shell, path: "install-heroku-cli.sh"
   config.vm.provision :shell, path: 'install-phantomjs.sh'
 

--- a/install-python.sh
+++ b/install-python.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# This script installs python and related tooling
+#
+# This script must be run as root:
+# sudo sh install-python.sh
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root" 1>&2
+    exit 1
+fi
+
+# Need to make python3 the default version
+
+sudo apt-get update
+
+sudo apt-get -y install python3-pip
+
+pip3 install --user pipenv tox
+
+python3 --version
+pip3 --version


### PR DESCRIPTION
I'm not sure whether this is quite ready, but it is far enough that I want to ask a question or two.

I've used this branch locally to spin up a vagrant box, but there are two questions I've got about whether the setup goes far enough:

1) It looks like this leaves python2 infrastructure in place with the `python` command, while python3 uses `python3`. Ditto for pip and pip3. Is this accurate? The python community documentation I see references this setup, but then I look at things like the carbon documentation and it references just `pip install .` instead of `pip3 install .` - which is what I had to do.

2) I've had to use sudo to get `pip install` to complete correctly, across a few different python projects. I'm guessing that this is a setup problem that I've created somewhere, but my *nix skills apparently aren't strong enough here.