### PR TITLE
Adds python 3.6 for Wagtail use

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "install-heroku-cli.sh"
   config.vm.provision :shell, path: 'install-phantomjs.sh'
   config.vm.provision :shell, path: "install-python.sh", args: "3.7"
+  config.vm.provision :shell, path: "install-python.sh", args: "3.6"
 
   config.vm.synced_folder ENV['SYNCED_FOLDER'] || "src", "/vagrant/src"
 


### PR DESCRIPTION
This adds Python3.6 to the list of available python versions (in addition to 3.5 and 3.7, which seem to already be available)